### PR TITLE
Отменяет перемещение по полю при нажатии 'управляющих' клавиш

### DIFF
--- a/js/jquery.crossword.js
+++ b/js/jquery.crossword.js
@@ -77,7 +77,10 @@
 								break;
 						}
 						
-						if ( e.keyCode === 9) {
+						if (
+                            e.keyCode >= 9 &&
+                            e.keyCode < 32
+                        ) {
 							return false;
 						} else if (
 							e.keyCode === 37 ||


### PR DESCRIPTION
При нажатии на Shift, Alt и тп перемещение по полю кроссворда не требуется.
Пример: сейчас смена раскладки клавиатуры по Alt+Shift приводит к перемещению на 3 позиции вправо или вниз

Клавиши для которых не будет производиться перемещение:
Shift, Control, Alt, и их сочетания, CapsLock, Escape
